### PR TITLE
feat: update protobuf to allow reql `format`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
 PROTO_FILE_NAME = "ql2.proto"
-PROTO_FILE_URL = "https://raw.githubusercontent.com/RethinkDB/rethinkdb/next/src/rdb_protocol/#{PROTO_FILE_NAME}"
+PROTO_FILE_URL = "https://raw.githubusercontent.com/RethinkDB/rethinkdb/80b4c72a564230bccc761183ef27bca00fe9a012/src/rdb_protocol/#{PROTO_FILE_NAME}"
 
 PROTO_RB_FILE = "../lib/ql2.pb.rb"
 

--- a/rethinkdb.gemspec
+++ b/rethinkdb.gemspec
@@ -1,14 +1,14 @@
 
 Gem::Specification.new do |s|
   s.name      = 'rethinkdb'
-  s.version   = '2.4.0.0'
+  s.version   = '2.5.0.0'
   s.summary   = 'This package provides the Ruby driver library for the RethinkDB database server.'
   s.author    = 'RethinkDB Inc.'
   s.email     = 'bugs@rethinkdb.com'
   s.homepage  = 'https://rethinkdb.com'
   s.license   = 'Apache-2.0'
   s.files     = Dir['lib/*.rb']
-  
+
   s.required_ruby_version = '>= 1.9.0'
 
   s.add_development_dependency 'rspec'


### PR DESCRIPTION
**Description**

Add the new `format` command.

**Code examples**

```rb
2.6.10 :008 > r.format("{hello} Gabor", { :hello => "Hello" }).run()
 => "Hello Gabor"
```

**Checklist**

- [x] I have read and agreed to the [RethinkDB Contributor License Agreement](http://rethinkdb.com/community/cla/)

**References**

* https://github.com/rethinkdb/rethinkdb/pull/7066
